### PR TITLE
count should be an int, not a string

### DIFF
--- a/includes/DataStore.php
+++ b/includes/DataStore.php
@@ -155,7 +155,7 @@ class DataStore
             $result = $query->execute();
             $event = ['exercise' => [
                 'type' => $exercise,
-                'count' => $reps,
+                'count' => (int)$reps,
                 'user' => $email,
                 'office' => $office
             ]];


### PR DESCRIPTION
Keen.io sum will not convert the string "12" to the int 12 when doing sum analysis
